### PR TITLE
Issue #28

### DIFF
--- a/src/main/java/org/terracotta/offheapstore/OffHeapHashMap.java
+++ b/src/main/java/org/terracotta/offheapstore/OffHeapHashMap.java
@@ -2040,7 +2040,7 @@ public class OffHeapHashMap<K, V> extends AbstractMap<K, V> implements MapIntern
 
       if (isTerminating(entry)) {
         return null;
-      } else if (keyEquals(key, hash, readLong(entry, ENCODING), entry.get(KEY_HASHCODE))) {
+      } else if (isPresent(entry) && keyEquals(key, hash, readLong(entry, ENCODING), entry.get(KEY_HASHCODE))) {
         long existingEncoding = readLong(entry, ENCODING);
         int existingStatus = entry.get(STATUS);
         MetadataTuple<V> existingValue = metadataTuple(
@@ -2075,9 +2075,6 @@ public class OffHeapHashMap<K, V> extends AbstractMap<K, V> implements MapIntern
       }
     }
 
-    // hit reprobe limit - must rehash
-    expand(start, limit);
-
-    return computeIfPresentWithMetadata(key, remappingFunction);
+    return null;
   }
 }

--- a/src/test/java/org/terracotta/offheapstore/AbstractOffHeapMapIT.java
+++ b/src/test/java/org/terracotta/offheapstore/AbstractOffHeapMapIT.java
@@ -666,6 +666,16 @@ public abstract class AbstractOffHeapMapIT {
     assertThat(map.get(keyB), nullValue());
     assertThat(map.get(keyA), nullValue());
     assertThat(map.size(), is(0));
+
+    assertThat(doComputeIfPresentWithMetadata(map, keyA, new BiFunction<SpecialInteger, MetadataTuple<SpecialInteger>, MetadataTuple<SpecialInteger>>() {
+      @Override
+      public MetadataTuple<SpecialInteger> apply(SpecialInteger t, MetadataTuple<SpecialInteger> u) {
+        return null;
+      }
+    }), nullValue());
+    assertThat(map.get(keyB), nullValue());
+    assertThat(map.get(keyA), nullValue());
+    assertThat(map.size(), is(0));
   }
 
   private static void testEmptyMap(Generator g, Map<SpecialInteger, SpecialInteger> m) {


### PR DESCRIPTION
    - Ensure keys are 'present' before comparing in computeIfPresentWithMetadata
    - Ensure that we return null on reaching the end of the probe sequence in computeIfPresentWithMetadata