### PR TITLE
Add ability for OffheapStorageArea to always copy

### DIFF
--- a/src/main/java/org/terracotta/offheapstore/paging/OffHeapStorageArea.java
+++ b/src/main/java/org/terracotta/offheapstore/paging/OffHeapStorageArea.java
@@ -204,11 +204,15 @@ public class OffHeapStorageArea {
   }
 
   public ByteBuffer readBuffer(long address, int length) {
+    return readBuffer(address, length, false);
+  }
+
+  public ByteBuffer readBuffer(long address, int length, boolean forceCopy) {
     int pageIndex = pageIndexFor(address);
     int pageAddress = pageAddressFor(address);
     int pageSize = pageSizeFor(pageIndex);
 
-    if (pageAddress + length <= pageSize) {
+    if (!forceCopy && pageAddress + length <= pageSize) {
       ByteBuffer buffer = pages.get(pageIndex).asByteBuffer();
       return ((ByteBuffer) buffer.duplicate().limit(pageAddress + length).position(pageAddress)).slice().asReadOnlyBuffer();
     } else {


### PR DESCRIPTION
In some cases, you read a buffer via OHSA.readBuffer(), and
you always know you need a copy. Unfortunately, you can't always
tell; subject to buffer length and page size and location, you may
or may not get a copy.

Here we add a 3 arg readbuffer() call which allows the user to
specific that they want a copy.