### PR TITLE
Perform allocation in parallel

### DIFF
--- a/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
+++ b/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
@@ -155,6 +155,19 @@ public class UpfrontAllocatingPageSource implements PageSource {
         }
     }
 
+  /**
+   * Return the total allocated capacity, used or not
+   *
+   * @return the total capacity
+   */
+  public long getCapacity() {
+    long capacity = 0;
+    for(ByteBuffer buffer : buffers) {
+      capacity += buffer.capacity();
+    }
+    return capacity;
+  }
+
     /**
      * Allocates a byte buffer of at least the given size.
      * <p>

--- a/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
+++ b/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
@@ -145,7 +145,9 @@ public class UpfrontAllocatingPageSource implements PageSource {
                   DebuggingUtils.toBase2SuffixedString(toAllocate), DebuggingUtils.toBase2SuffixedString(freePhysical));
         }
 
-        LOGGER.debug("Allocating {}B in chunks", DebuggingUtils.toBase2SuffixedString(toAllocate));
+        if(LOGGER.isInfoEnabled()) {
+          LOGGER.info("Allocating {}B in chunks", DebuggingUtils.toBase2SuffixedString(toAllocate));
+        }
 
         for (ByteBuffer buffer : allocateBackingBuffers(source, toAllocate, maxChunk, minChunk, fixed)) {
           sliceAllocators.add(new PowerOfTwoAllocator(buffer.capacity()));
@@ -497,7 +499,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
         throw new IllegalArgumentException("Failed to create allocator log", e);
       }
 
-      final long start = (LOGGER.isDebugEnabled() ? System.nanoTime() : 0);
+      final long start = (LOGGER.isInfoEnabled() ? System.nanoTime() : 0);
 
       if (allocatorLog != null) {
         allocatorLog.printf("timestamp,duration,size,physfree,totalswap,freeswap,committed%n");
@@ -541,9 +543,9 @@ public class UpfrontAllocatingPageSource implements PageSource {
         allocatorLog.close();
       }
 
-      if(LOGGER.isDebugEnabled()) {
+      if(LOGGER.isInfoEnabled()) {
         long duration = System.nanoTime() - start;
-        LOGGER.debug("Took {} ms to create off-heap storage of {}B.", TimeUnit.NANOSECONDS.toMillis(duration), DebuggingUtils.toBase2SuffixedString(toAllocate));
+        LOGGER.info("Took {} ms to create off-heap storage of {}B.", TimeUnit.NANOSECONDS.toMillis(duration), DebuggingUtils.toBase2SuffixedString(toAllocate));
       }
 
       return Collections.unmodifiableCollection(buffers);
@@ -579,6 +581,10 @@ public class UpfrontAllocatingPageSource implements PageSource {
 
         if (allocatorLog != null) {
           allocatorLog.printf("%d,%d,%d,%d,%d,%d,%d%n", System.nanoTime() - start, blockDuration, currentAllocation, PhysicalMemory.freePhysicalMemory(), PhysicalMemory.totalSwapSpace(), PhysicalMemory.freeSwapSpace(), PhysicalMemory.ourCommittedVirtualMemory());
+        }
+
+        if(LOGGER.isDebugEnabled()) {
+          LOGGER.debug("{}B chunk allocated", DebuggingUtils.toBase2SuffixedString(currentAllocation));
         }
       }
     }

--- a/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
+++ b/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
@@ -498,7 +498,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
 
       final long start = (LOGGER.isDebugEnabled() ? System.nanoTime() : 0);
 
-      final Collection<ByteBuffer> buffers = new ArrayList<ByteBuffer>((int)toAllocate / maxChunk + 10); // guess the number of buffers and add some padding just in case
+      final Collection<ByteBuffer> buffers = new ArrayList<ByteBuffer>((int)(toAllocate / maxChunk + 10)); // guess the number of buffers and add some padding just in case
 
       final PrintStream allocatorLog = createAllocatorLog(toAllocate, maxChunk, minChunk);
 
@@ -509,7 +509,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
 
         ExecutorService executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 
-        List<Future<Long>> futures = new ArrayList<Future<Long>>((int)toAllocate / maxChunk + 1);
+        List<Future<Long>> futures = new ArrayList<Future<Long>>((int)(toAllocate / maxChunk + 1));
 
         for (long dispatched = 0; dispatched < toAllocate; ) {
           final int currentChunkSize = (int)Math.min(maxChunk, toAllocate - dispatched);

--- a/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
+++ b/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
@@ -504,7 +504,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
 
       try {
         if (allocatorLog != null) {
-          allocatorLog.printf("timestamp,duration,size,physfree,totalswap,freeswap,committed%n");
+          allocatorLog.printf("timestamp,threadid,duration,size,physfree,totalswap,freeswap,committed%n");
         }
 
         ExecutorService executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
@@ -588,7 +588,8 @@ public class UpfrontAllocatingPageSource implements PageSource {
         allocated += currentAllocation;
 
         if (allocatorLog != null) {
-          allocatorLog.printf("%d,%d,%d,%d,%d,%d,%d%n", System.nanoTime() - start, blockDuration, currentAllocation, PhysicalMemory.freePhysicalMemory(), PhysicalMemory.totalSwapSpace(), PhysicalMemory.freeSwapSpace(), PhysicalMemory.ourCommittedVirtualMemory());
+          allocatorLog.printf("%d,%d,%d,%d,%d,%d,%d,%d%n", System.nanoTime() - start,
+            Thread.currentThread().getId(),  blockDuration, currentAllocation, PhysicalMemory.freePhysicalMemory(), PhysicalMemory.totalSwapSpace(), PhysicalMemory.freeSwapSpace(), PhysicalMemory.ourCommittedVirtualMemory());
         }
 
         if(LOGGER.isDebugEnabled()) {

--- a/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
+++ b/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
@@ -496,7 +496,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
    */
     private static Collection<ByteBuffer> allocateBackingBuffers(final BufferSource source, long toAllocate, int maxChunk, final int minChunk, final boolean fixed) {
 
-      final long start = (LOGGER.isInfoEnabled() ? System.nanoTime() : 0);
+      final long start = (LOGGER.isDebugEnabled() ? System.nanoTime() : 0);
 
       final Collection<ByteBuffer> buffers = new ArrayList<ByteBuffer>((int)toAllocate / maxChunk + 10); // guess the number of buffers and add some padding just in case
 
@@ -551,9 +551,9 @@ public class UpfrontAllocatingPageSource implements PageSource {
         }
       }
 
-      if(LOGGER.isInfoEnabled()) {
+      if(LOGGER.isDebugEnabled()) {
         long duration = System.nanoTime() - start;
-        LOGGER.info("Took {} ms to create off-heap storage of {}B.", TimeUnit.NANOSECONDS.toMillis(duration), DebuggingUtils.toBase2SuffixedString(toAllocate));
+        LOGGER.debug("Took {} ms to create off-heap storage of {}B.", TimeUnit.NANOSECONDS.toMillis(duration), DebuggingUtils.toBase2SuffixedString(toAllocate));
       }
 
       return Collections.unmodifiableCollection(buffers);

--- a/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
+++ b/src/main/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSource.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2015 Terracotta, Inc., a Software AG company.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,21 +15,8 @@
  */
 package org.terracotta.offheapstore.paging;
 
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.IdentityHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.TreeSet;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.terracotta.offheapstore.buffersource.BufferSource;
 import org.terracotta.offheapstore.storage.allocator.PowerOfTwoAllocator;
 import org.terracotta.offheapstore.util.DebuggingUtils;
@@ -39,14 +26,25 @@ import org.terracotta.offheapstore.util.PhysicalMemory;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
+import java.util.IdentityHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NavigableSet;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
-import static org.terracotta.offheapstore.storage.allocator.PowerOfTwoAllocator.Packing.FLOOR;
 import static org.terracotta.offheapstore.storage.allocator.PowerOfTwoAllocator.Packing.CEILING;
+import static org.terracotta.offheapstore.storage.allocator.PowerOfTwoAllocator.Packing.FLOOR;
 
 /**
  * An upfront allocating direct byte buffer source.
@@ -77,7 +75,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
 
     private final SortedMap<Long, Runnable> risingThresholds = new TreeMap<Long, Runnable>();
     private final SortedMap<Long, Runnable> fallingThresholds = new TreeMap<Long, Runnable>();
-    
+
     private final List<PowerOfTwoAllocator> sliceAllocators = new ArrayList<PowerOfTwoAllocator>();
     private final List<PowerOfTwoAllocator> victimAllocators = new ArrayList<PowerOfTwoAllocator>();
 
@@ -87,7 +85,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
      * TODO : currently the TreeSet along with the comparator above works for the
      * subSet queries due to the alignment properties of the region allocation
      * being used here.  I more flexible implementation might involve switching
-     * to using an AATreeSet subclass - that would also require me to finish 
+     * to using an AATreeSet subclass - that would also require me to finish
      * writing the subSet implementation for that class.
      */
     private final List<NavigableSet<Page>> victims = new ArrayList<NavigableSet<Page>>();
@@ -95,45 +93,59 @@ public class UpfrontAllocatingPageSource implements PageSource {
     private volatile int availableSet = ~0;
 
     /**
-     * Create an up-front allocating buffer source of {@code max} total bytes, in
-     * {@code chunk} byte chunks.
+     * Create an up-front allocating buffer source of {@code toAllocate} total bytes, in
+     * {@code chunkSize} byte chunks.
      *
-     * @param source source from which initial buffers will be allocated
-     * @param max    total space to allocate
-     * @param chunk  chunk size to allocate in
+     * @param source     source from which initial buffers will be allocated
+     * @param toAllocate total space to allocate in bytes
+     * @param chunkSize  chunkSize size to allocate in bytes
      */
-    public UpfrontAllocatingPageSource(BufferSource source, long max, int chunk) {
-        this(source, max, chunk, -1, true);
+    public UpfrontAllocatingPageSource(BufferSource source, long toAllocate, int chunkSize) {
+        this(source, toAllocate, chunkSize, -1, true);
     }
 
     /**
-     * Create an up-front allocating buffer source of {@code max} total bytes, in
+     * Create an up-front allocating buffer source of {@code toAllocate} total bytes, in
      * maximally sized chunks, within the given bounds.
      *
-     * @param source   source from which initial buffers will be allocated
-     * @param max      total space to allocate
-     * @param maxChunk the largest chunk size
-     * @param minChunk the smallest chunk size
+     * @param source     source from which initial buffers will be allocated
+     * @param toAllocate total space to allocate in bytes
+     * @param maxChunk   the largest chunk size in bytes
+     * @param minChunk   the smallest chunk size in bytes
      */
-    public UpfrontAllocatingPageSource(BufferSource source, long max, int maxChunk, int minChunk) {
-        this(source, max, maxChunk, minChunk, false);
+    public UpfrontAllocatingPageSource(BufferSource source, long toAllocate, int maxChunk, int minChunk) {
+        this(source, toAllocate, maxChunk, minChunk, false);
     }
 
-    private UpfrontAllocatingPageSource(BufferSource source, long max, int maxChunk, int minChunk, boolean fixed) {
+  /**
+   * Create an up-front allocating buffer source of {@code toAllocate} total bytes, in
+   * maximally sized chunks, within the given bounds.
+   * <p>
+   * By default we try to allocate chunks of {@code maxChunk} size. However, unless {@code fixed} is true, in case of
+   * allocation failure, we will try to allocate half-smaller chunks. We do not allocate chunks smaller than {@code minChunk}
+   * though.
+   *
+   * @param source     source from which initial buffers will be allocated
+   * @param toAllocate total space to allocate in bytes
+   * @param maxChunk   the largest chunk size in bytes
+   * @param minChunk   the smallest chunk size in bytes
+   * @param fixed      if the chunks should all be of size {@code maxChunk} or can be smaller
+   */
+    private UpfrontAllocatingPageSource(BufferSource source, long toAllocate, int maxChunk, int minChunk, boolean fixed) {
         Long totalPhysical = PhysicalMemory.totalPhysicalMemory();
         Long freePhysical = PhysicalMemory.freePhysicalMemory();
-        if (totalPhysical != null && max > totalPhysical) {
-          throw new IllegalArgumentException("Attempting to allocate " + DebuggingUtils.toBase2SuffixedString(max) + "B of memory "
+        if (totalPhysical != null && toAllocate > totalPhysical) {
+          throw new IllegalArgumentException("Attempting to allocate " + DebuggingUtils.toBase2SuffixedString(toAllocate) + "B of memory "
                   + "when the host only contains " + DebuggingUtils.toBase2SuffixedString(totalPhysical) + "B of physical memory");
         }
-        if (freePhysical != null && max > freePhysical) {
+        if (freePhysical != null && toAllocate > freePhysical) {
           LOGGER.warn("Attempting to allocate {}B of offheap when there is only {}B of free physical memory - some paging will therefore occur.",
-                  DebuggingUtils.toBase2SuffixedString(max), DebuggingUtils.toBase2SuffixedString(freePhysical));
+                  DebuggingUtils.toBase2SuffixedString(toAllocate), DebuggingUtils.toBase2SuffixedString(freePhysical));
         }
 
-        LOGGER.debug("Allocating {}B in chunks", DebuggingUtils.toBase2SuffixedString(max));
+        LOGGER.debug("Allocating {}B in chunks", DebuggingUtils.toBase2SuffixedString(toAllocate));
 
-        for (ByteBuffer buffer : allocateBackingBuffers(source, max, maxChunk, minChunk, fixed)) {
+        for (ByteBuffer buffer : allocateBackingBuffers(source, toAllocate, maxChunk, minChunk, fixed)) {
           sliceAllocators.add(new PowerOfTwoAllocator(buffer.capacity()));
           victimAllocators.add(new PowerOfTwoAllocator(buffer.capacity()));
           victims.add(new TreeSet<Page>(REGION_COMPARATOR));
@@ -233,7 +245,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
           sliceAllocator.free(r.address, r.size);
           victimAllocator.free(r.address, r.size);
         }
-        
+
         if (results.size() == targets.size()) {
           for (Page p : targets) {
             victimAllocator.free(p.address(), p.size());
@@ -251,7 +263,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
           }
         }
       }
-      
+
       try {
         return allocateAsThief(size, victim, owner);
       } finally {
@@ -338,7 +350,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
         }
         return sum;
     }
-    
+
     public long getAllocatedSizeUnSync() {
         long sum = 0;
         for (PowerOfTwoAllocator a : sliceAllocators) {
@@ -346,7 +358,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
         }
         return sum;
     }
-    
+
     private boolean isUnavailable(int size) {
         return (availableSet & size) == 0;
     }
@@ -381,7 +393,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
       } else {
         thresholds = Collections.emptyList();
       }
-      
+
       for (Runnable r : thresholds) {
         try {
           r.run();
@@ -390,7 +402,7 @@ public class UpfrontAllocatingPageSource implements PageSource {
         }
       }
     }
-    
+
     /**
      * Adds an allocation threshold action.
      * <p>
@@ -403,9 +415,9 @@ public class UpfrontAllocatingPageSource implements PageSource {
      * synchronously with the triggering allocation.  This means care must be taken
      * to avoid mutating any map that uses this page source from within the action
      * otherwise deadlocks may result.  Exceptions thrown by the action will be
-     * caught and logged by the page source and will not be propagated on the 
+     * caught and logged by the page source and will not be propagated on the
      * allocating thread.
-     * 
+     *
      * @param direction new actions direction
      * @param threshold new actions threshold level
      * @param action fired on breaching the threshold
@@ -420,12 +432,12 @@ public class UpfrontAllocatingPageSource implements PageSource {
       }
       throw new AssertionError();
     }
-    
+
     /**
      * Removes an allocation threshold action.
      * <p>
      * Removes the allocation threshold action for the given level and direction.
-     * 
+     *
      * @param direction registered actions direction
      * @param threshold registered actions threshold level
      * @return the removed condition or {@code null} if no action was present.
@@ -440,47 +452,57 @@ public class UpfrontAllocatingPageSource implements PageSource {
       throw new AssertionError();
     }
 
-    private static Collection<ByteBuffer> allocateBackingBuffers(BufferSource source, long max, int maxChunk, int minChunk, boolean fixed) {
-      Collection<ByteBuffer> buffers = new LinkedList<ByteBuffer>();
+    private static Collection<ByteBuffer> allocateBackingBuffers(BufferSource source, long toAllocate, int maxChunk, int minChunk, boolean fixed) {
 
       PrintStream allocatorLog;
       try {
-        allocatorLog = createAllocatorLog(max, maxChunk, minChunk);
+        allocatorLog = createAllocatorLog(toAllocate, maxChunk, minChunk);
       } catch (IOException e) {
         LOGGER.warn("Exception creating allocation log", e);
         allocatorLog = null;
       }
-      long start = System.nanoTime();
+
+      long start = 0;
+
+      if(LOGGER.isDebugEnabled()) {
+        start = System.nanoTime();
+      }
+
       if (allocatorLog != null) {
         allocatorLog.printf("timestamp,duration,size,allocated,physfree,totalswap,freeswap,committed%n");
       }
-      long progressStep = Math.max(PROGRESS_LOGGING_THRESHOLD, (long) (max * PROGRESS_LOGGING_STEP_SIZE));
+      long progressStep = Math.max(PROGRESS_LOGGING_THRESHOLD, (long) (toAllocate * PROGRESS_LOGGING_STEP_SIZE));
       long lastFailureAt = 0;
       long currentChunkSize = maxChunk;
       long allocated = 0;
       long nextProgressLogAt = progressStep;
-      while (allocated < max) {
+
+      Collection<ByteBuffer> buffers = new ArrayList<ByteBuffer>((int) toAllocate / maxChunk + 10); // guess the number of buffers and add some padding just in case
+
+      while (allocated < toAllocate) {
         long blockStart = System.nanoTime();
-        ByteBuffer b = source.allocateBuffer((int) Math.min(currentChunkSize, (max - allocated)));
+        ByteBuffer b = source.allocateBuffer((int) Math.min(currentChunkSize, (toAllocate - allocated)));
         long blockDuration = System.nanoTime() - blockStart;
         if (b == null) {
           if (fixed || (currentChunkSize >>> 1) < minChunk) {
             throw new IllegalArgumentException("An attempt was made to allocate more off-heap memory than the JVM can allow." +
                     " The limit on off-heap memory size is given by the -XX:MaxDirectMemorySize command (or equivalent).");
           } else {
-            LOGGER.debug("Allocated {}B in {}B chunks.", new Object[]{DebuggingUtils.toBase2SuffixedString(allocated - lastFailureAt), DebuggingUtils.toBase2SuffixedString(currentChunkSize)});
+            if(LOGGER.isDebugEnabled()) {
+              LOGGER.debug("Allocated {}B in {}B chunks.", DebuggingUtils.toBase2SuffixedString(allocated - lastFailureAt), DebuggingUtils.toBase2SuffixedString(currentChunkSize));
+            }
             currentChunkSize >>>= 1;
             lastFailureAt = allocated;
           }
         } else {
           buffers.add(b);
           allocated += b.capacity();
-          
+
           if (allocatorLog != null) {
             allocatorLog.printf("%d,%d,%d,%d,%d,%d,%d,%d%n", System.nanoTime() - start, blockDuration, b.capacity(), allocated, PhysicalMemory.freePhysicalMemory(), PhysicalMemory.totalSwapSpace(), PhysicalMemory.freeSwapSpace(), PhysicalMemory.ourCommittedVirtualMemory());
           }
           if (allocated > nextProgressLogAt) {
-            LOGGER.info("Allocation {}% complete", (100 * allocated) / max);
+            LOGGER.info("Allocation {}% complete", (100 * allocated) / toAllocate);
             nextProgressLogAt += progressStep;
           }
         }
@@ -488,9 +510,12 @@ public class UpfrontAllocatingPageSource implements PageSource {
       if (allocatorLog != null) {
         allocatorLog.close();
       }
-      LOGGER.debug("Allocated {}B in {}B chunks.", new Object[]{DebuggingUtils.toBase2SuffixedString(allocated - lastFailureAt), DebuggingUtils.toBase2SuffixedString(currentChunkSize)});
-      long duration = System.nanoTime() - start;
-      LOGGER.debug("Took {} ms to create off-heap storage of {}B.", TimeUnit.NANOSECONDS.toMillis(duration), DebuggingUtils.toBase2SuffixedString(max));
+
+      if(LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Allocated {}B in {}B chunks.", DebuggingUtils.toBase2SuffixedString(allocated - lastFailureAt), DebuggingUtils.toBase2SuffixedString(currentChunkSize));
+        long duration = System.nanoTime() - start;
+        LOGGER.debug("Took {} ms to create off-heap storage of {}B.", TimeUnit.NANOSECONDS.toMillis(duration), DebuggingUtils.toBase2SuffixedString(toAllocate));
+      }
       return Collections.unmodifiableCollection(buffers);
     }
 

--- a/src/test/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSourceTest.java
+++ b/src/test/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSourceTest.java
@@ -193,7 +193,7 @@ public class UpfrontAllocatingPageSourceTest {
       Assert.assertThat(reader.readLine(), equalTo("Allocating: 128KB"));
       Assert.assertThat(reader.readLine(), equalTo("Max Chunk: 1KB"));
       Assert.assertThat(reader.readLine(), equalTo("Min Chunk: 512B"));
-      Assert.assertThat(reader.readLine(), equalTo("timestamp,duration,size,physfree,totalswap,freeswap,committed"));
+      Assert.assertThat(reader.readLine(), equalTo("timestamp,threadid,duration,size,physfree,totalswap,freeswap,committed"));
       while (true) {
         String line = reader.readLine();
         if (line == null) {
@@ -202,7 +202,7 @@ public class UpfrontAllocatingPageSourceTest {
           Assert.assertThat(reader.readLine(), new TypeSafeMatcher<String>() {
             @Override
             protected boolean matchesSafely(String t) {
-              return t.matches("(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null)");
+              return t.matches("(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null)");
             }
 
             @Override

--- a/src/test/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSourceTest.java
+++ b/src/test/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSourceTest.java
@@ -187,7 +187,7 @@ public class UpfrontAllocatingPageSourceTest {
       Assert.assertThat(reader.readLine(), equalTo("Allocating: 128KB"));
       Assert.assertThat(reader.readLine(), equalTo("Max Chunk: 1KB"));
       Assert.assertThat(reader.readLine(), equalTo("Min Chunk: 512B"));
-      Assert.assertThat(reader.readLine(), equalTo("timestamp,duration,size,allocated,physfree,totalswap,freeswap,committed"));
+      Assert.assertThat(reader.readLine(), equalTo("timestamp,duration,size,physfree,totalswap,freeswap,committed"));
       while (true) {
         String line = reader.readLine();
         if (line == null) {
@@ -196,7 +196,7 @@ public class UpfrontAllocatingPageSourceTest {
           Assert.assertThat(reader.readLine(), new TypeSafeMatcher<String>() {
             @Override
             protected boolean matchesSafely(String t) {
-              return t.matches("(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null)");
+              return t.matches("(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null),(?:\\d+|null)");
             }
 
             @Override

--- a/src/test/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSourceTest.java
+++ b/src/test/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSourceTest.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2015 Terracotta, Inc., a Software AG company.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,17 +15,15 @@
  */
 package org.terracotta.offheapstore.paging;
 
-import org.terracotta.offheapstore.paging.Page;
-import org.terracotta.offheapstore.paging.UnlimitedPageSource;
-import org.terracotta.offheapstore.paging.UpfrontAllocatingPageSource;
-import org.terracotta.offheapstore.paging.PageSource;
-import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.Map;
-
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.CombinableMatcher;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-
+import org.junit.rules.TemporaryFolder;
 import org.terracotta.offheapstore.buffersource.BufferSource;
 import org.terracotta.offheapstore.buffersource.HeapBufferSource;
 import org.terracotta.offheapstore.buffersource.OffHeapBufferSource;
@@ -40,21 +38,17 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
-import org.hamcrest.core.CombinableMatcher;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import static org.hamcrest.collection.IsArray.array;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.hamcrest.core.IsAnything.anything;
 import static org.hamcrest.core.IsEqual.equalTo;
-import org.junit.rules.TemporaryFolder;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 
 public class UpfrontAllocatingPageSourceTest {
 
@@ -63,12 +57,12 @@ public class UpfrontAllocatingPageSourceTest {
   public void lock() {
     LOCK.lock();
   }
-  
+
   @After
   public void unlock() {
     LOCK.unlock();
   }
-  
+
   @Test
   public void testUpfrontAllocatingBufferSource() {
     PageSource source = new UpfrontAllocatingPageSource(new OffHeapBufferSource(), 2 * 1024, 1024);
@@ -78,14 +72,14 @@ public class UpfrontAllocatingPageSourceTest {
     Assert.assertEquals(1024, p.size());
 
     Assert.assertNull(source.allocate(1024 * 2, false, false, null));
-    
+
     for (int i = 0; i < 8; i++) {
       Assert.assertEquals(128, source.allocate(128, false, false, null).size());
     }
 
     Assert.assertNull(source.allocate(1, false, false, null));
   }
-  
+
   @Test
   public void testUpfrontAllocationFreeing() {
     PageSource test = new UpfrontAllocatingPageSource(new OffHeapBufferSource(), 1024, 1024);
@@ -94,7 +88,7 @@ public class UpfrontAllocatingPageSourceTest {
 
     test.free(p);
   }
-  
+
   @Test
   public void testUpfrontAllocationResizing() {
     Map<String, String> map = new ConcurrentOffHeapHashMap<String, String>(new UnlimitedPageSource(new OffHeapBufferSource()), new Factory<StringStorageEngine>() {
@@ -105,7 +99,7 @@ public class UpfrontAllocatingPageSourceTest {
         return new StringStorageEngine(PointerSize.INT, source, 1);
       }
     }, 1, 4);
-    
+
     for (int i = 0; i < 100; i++) {
       map.put(Integer.toString(i), "Hello World");
       Assert.assertTrue(map.containsKey(Integer.toString(i)));
@@ -173,7 +167,7 @@ public class UpfrontAllocatingPageSourceTest {
 
   @Rule
   public final TemporaryFolder tempFolder = new TemporaryFolder();
-  
+
   @Test
   public void testAllocatorLogging() throws IOException {
     File logLocation = tempFolder.newFolder("testAllocatorLogging");
@@ -220,7 +214,7 @@ public class UpfrontAllocatingPageSourceTest {
   static class TestChunkedBufferSource implements BufferSource {
 
     private final Map<Integer, Integer> chunks;
-    
+
     public TestChunkedBufferSource(Map<Integer, Integer> chunks) {
       this.chunks = chunks;
     }

--- a/src/test/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSourceTest.java
+++ b/src/test/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSourceTest.java
@@ -64,6 +64,12 @@ public class UpfrontAllocatingPageSourceTest {
   }
 
   @Test
+  public void testGetCapacity() {
+    UpfrontAllocatingPageSource source = new UpfrontAllocatingPageSource(new OffHeapBufferSource(), 2 * 1024, 1024);
+    Assert.assertEquals(2 * 1024, source.getCapacity());
+  }
+
+  @Test
   public void testUpfrontAllocatingBufferSource() {
     PageSource source = new UpfrontAllocatingPageSource(new OffHeapBufferSource(), 2 * 1024, 1024);
 

--- a/src/test/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSourceTest.java
+++ b/src/test/java/org/terracotta/offheapstore/paging/UpfrontAllocatingPageSourceTest.java
@@ -126,7 +126,7 @@ public class UpfrontAllocatingPageSourceTest {
   public void testVariableChunkSizesSuccess() {
     Map<Integer, Integer> chunks = new HashMap<Integer, Integer>();
 
-    //Allocate 128k sucessfully
+    //Allocate 128k successfully
     chunks.put(64 * 1024, 1);
     chunks.put(32 * 1024, 1);
     chunks.put(16 * 1024, 2);
@@ -139,7 +139,7 @@ public class UpfrontAllocatingPageSourceTest {
   public void testVariableChunkSizesFailureDueToLimitation() {
     Map<Integer, Integer> chunks = new HashMap<Integer, Integer>();
 
-    //Allocate 128k sucessfully
+    //Allocate 128k successfully
     chunks.put(64 * 1024, 1);
     chunks.put(32 * 1024, 1);
     chunks.put(16 * 1024, 2);
@@ -157,7 +157,7 @@ public class UpfrontAllocatingPageSourceTest {
   public void testVariableChunkSizesFailureDueToExhaustion() {
     Map<Integer, Integer> chunks = new HashMap<Integer, Integer>();
 
-    //Allocate 128k sucessfully
+    //Allocate 128k successfully
     chunks.put(64 * 1024, 1);
     chunks.put(32 * 1024, 1);
     chunks.put(16 * 1024, 1);


### PR DESCRIPTION
Perform allocation in parallel.

Things I'm not sure about in this PR:
* In case of interruption, I return what was allocated so far and set the interrupt flag
* No progress log anymore. Just a message per allocation
* No currently allocated size in the allocation log