### PR TITLE
Use logback for logging and add a log configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@ limitations under the License.
     </dependency>
 
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
@@ -74,12 +80,6 @@ limitations under the License.
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.10.19</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/terracotta/offheapstore/OffHeapHashMapTableResizeIT.java
+++ b/src/test/java/org/terracotta/offheapstore/OffHeapHashMapTableResizeIT.java
@@ -15,14 +15,14 @@
  */
 package org.terracotta.offheapstore;
 
-import org.terracotta.offheapstore.OffHeapHashMap;
 import java.util.Map;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.junit.Test;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+
+import org.slf4j.LoggerFactory;
 import org.terracotta.offheapstore.buffersource.OffHeapBufferSource;
 import org.terracotta.offheapstore.paging.UpfrontAllocatingPageSource;
 import org.terracotta.offheapstore.storage.IntegerStorageEngine;
@@ -39,11 +39,9 @@ public class OffHeapHashMapTableResizeIT {
 
   @Test
   public void testLargeTableResizes() {
-    Logger logger = Logger.getLogger("com.terracottatech.offheapstore.OffHeapHashMap");
+    Logger logger = (Logger)LoggerFactory.getLogger(OffHeapHashMap.class);
+    Level oldLevel = logger.getLevel();
     logger.setLevel(Level.ALL);
-    ConsoleHandler handler = new ConsoleHandler();
-    handler.setLevel(Level.ALL);
-    logger.addHandler(handler);
     try {
       Map<Integer, Integer> map = new OffHeapHashMap<Integer, Integer>(new UpfrontAllocatingPageSource(new OffHeapBufferSource(), 32 * 1024 * 1024, 32 * 1024 * 1024), new SplitStorageEngine<Integer, Integer>(new IntegerStorageEngine(), new IntegerStorageEngine()), 1);
 
@@ -51,8 +49,7 @@ public class OffHeapHashMapTableResizeIT {
         map.put(i, i);
       }
     } finally {
-      logger.setLevel(Level.INFO);
-      logger.removeHandler(handler);
+      logger.setLevel(oldLevel);
     }
   }
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,28 @@
+<!--
+Copyright 2015 Terracotta, Inc., a Software AG company.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
Logback because we use it (or log4j) for all our other projects. It is only in test scope. A logback configuration is provided to easily change it when needed.