### PR TITLE
Update logging components & correct test failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,10 @@ limitations under the License.
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.base.version>1.7.32</slf4j.base.version>
+    <slf4j.range.version>[${slf4j.base.version},1.7.9999)</slf4j.range.version>
+    <logback.base.version>1.2.11</logback.base.version>
+    <logback.range.version>[${logback.base.version},1.2.9999)</logback.range.version>
     <terracotta-os-snapshots-url>http://nexus.terracotta.eur.ad.sag/content/repositories/terracotta-os-snapshots</terracotta-os-snapshots-url>
     <terracotta-os-releases-url>http://nexus.terracotta.eur.ad.sag/content/repositories/terracotta-os-releases</terracotta-os-releases-url>
     <skipJavadoc>false</skipJavadoc>
@@ -49,13 +52,13 @@ limitations under the License.
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${slf4j.range.version}</version>
     </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
+      <version>${logback.range.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/terracotta/offheapstore/disk/storage/FileBackedStorageEngineTest.java
+++ b/src/test/java/org/terracotta/offheapstore/disk/storage/FileBackedStorageEngineTest.java
@@ -220,6 +220,7 @@ public class FileBackedStorageEngineTest extends AbstractDiskTest {
       Assert.assertArrayEquals(buffer, bytes);
     } finally {
       source.close();
+      Thread.interrupted();   // Clear interruption stats
     }
   }
 


### PR DESCRIPTION
This commit stream includes the following commits:

* Clear interruption to avoid UpfrontAllocatingPageSourceTest failure
* Use version range for logging components

The test update is to correct a locally-observed test failure.  